### PR TITLE
Enable testing with Jest

### DIFF
--- a/projects/@ngxp/store-service/testing/src/lib/mock-actions.ts
+++ b/projects/@ngxp/store-service/testing/src/lib/mock-actions.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'node_modules/rxjs';
+import { Subject } from 'rxjs';
 import { Actions } from '@ngrx/effects';
 
 export class MockActions {


### PR DESCRIPTION
The wrong import from node_modules/rxjs blocks using this library in combination with Jest testing framework.